### PR TITLE
solved 욕심쟁이판다 - 32ms 4048kb

### DIFF
--- a/Baekjoon/욕심쟁이판다/욕심쟁이판다_박주빈.cpp
+++ b/Baekjoon/욕심쟁이판다/욕심쟁이판다_박주빈.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int map[501][501];
+int visited[501][501] = { 0 , };
+int n;
+
+int dx[] = { -1, 1 ,0 ,0 };
+int dy[] = { 0, 0, -1, 1 };
+
+int dfs(int x, int y)
+{
+	if (visited[x][y])
+		return visited[x][y];
+
+	int result = 0;
+
+	for (int i = 0; i < 4; i++)
+	{
+		int nx = x + dx[i];
+		int ny = y + dy[i];
+
+		if (nx < 1 || ny < 1 || nx > n || ny > n)
+			continue;
+
+		if (map[x][y] >= map[nx][ny])
+			continue;
+
+		int val = dfs(nx, ny) + 1;
+
+		result = max(result, val);
+	}
+
+	return visited[x][y] = result;
+}
+
+int main()
+{
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+
+	cin >> n;
+
+	for (int i = 1; i <= n; i++)
+	{
+		for (int j = 1; j <= n; j++)
+			cin >> map[i][j];
+	}
+
+	int ans = 0;
+
+	for (int i = 1; i <= n; i++)
+	{
+		for (int j = 1; j <= n; j++)
+		{
+			if (visited[i][j])
+				continue;
+
+			ans = max(ans, dfs(i, j));
+		}
+	}
+
+	cout << ans + 1;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#90 

## 📝 풀이 후기
어려웠습니다.
모든칸에 dfs를 돌리면 시간초과가 나기 때문에 연산을 줄일 수 있는 방법을 찾아야 되는데,
어떤 칸이던 본인보다 큰 값을 찾아서 가다보면 특정 칸에서 이동할 수 있는 칸이 정해지기 때문에
똑같은 배열을 하나 더 만들어서 방문여부를 체크하고 최대값을 저장해두어
해당 칸에 방문하면 더 이상 중복된 연산을 시행하지않고, 저장된 값을 반환하는 식으로 
불필요한 계산을 줄이는 방법으로 구현하였습니다.

## 📚 문제 풀이 핵심 키워드
- dfs
- dp

## 🤔 리뷰로 궁금한 점
없습니다.

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?