### PR TITLE
solved 아이템줍기 - 0.06ms 4.21mb

### DIFF
--- a/Programmers/아이템줍기/아이템줍기_박주빈.cpp
+++ b/Programmers/아이템줍기/아이템줍기_박주빈.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int MAP[101][101];
+
+vector<vector<int>> Rect;
+int dx[] = { 1, -1, 0, 0 };
+int dy[] = { 0, 0, 1, -1 };
+
+bool rectCheck(int nx, int ny)
+{
+	for (auto figure : Rect)
+	{
+		if (figure[0] < nx && figure[1] < ny
+			&& figure[2] > nx && figure[3] > ny)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int BFS(int cx, int cy, int ix, int iy)
+{
+	queue<pair<int, pair<int, int>>> q;
+	q.push(make_pair(1, make_pair(cx, cy)));
+
+	MAP[cx][cy] = 1;
+
+	while (!q.empty())
+	{
+		int cost = q.front().first;
+		int x = q.front().second.first;
+		int y = q.front().second.second;
+		q.pop();
+
+		if (x == ix && y == iy)
+		{
+			return (cost - 1) / 2;
+		}
+
+		for (int i = 0; i < 4; i++)
+		{
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+
+			if (MAP[nx][ny] < 0 && !rectCheck(nx, ny))
+			{
+				MAP[nx][ny] = cost;
+				q.push(make_pair(cost + 1, make_pair(nx, ny)));
+			}
+		}
+	}
+
+	return -1;
+}
+
+int solution(vector<vector<int>> rect, int cx, int cy, int ix, int iy)
+{
+	for (auto figure : rect)
+	{
+		for (int i = figure[0] * 2; i <= figure[2] * 2; i++)
+			MAP[i][figure[1] * 2] = -1;
+
+		for (int i = figure[1] * 2; i <= figure[3] * 2; i++)
+			MAP[figure[0] * 2][i] = -1;
+
+		for (int i = figure[0] * 2; i <= figure[2] * 2; i++)
+			MAP[i][figure[3] * 2] = -1;
+
+		for (int i = figure[1] * 2; i <= figure[3] * 2; i++)
+			MAP[figure[2] * 2][i] = -1;
+
+		Rect.push_back({ figure[0] * 2, figure[1] * 2, figure[2] * 2, figure[3] * 2 });
+	}
+
+	return BFS(cx * 2, cy * 2, ix * 2, iy * 2);
+}


### PR DESCRIPTION
## 💿 풀이 문제
#91 

## 📝 풀이 후기
어려웠습니다.
테두리와 내부공간을 구분하여 큐에 값을 저장한 뒤 테두리를 따라 BFS를 이용하여 탐색하는데,
이 과정에서 좌표를 확장하지 않고 그대로 값을 넣으면 ㄷ자 모서리에서 길이 두갈래로 나뉘어
탐색이 잘못되는 케이스가 있는데, 이 부분을 고려하지 않으면 풀 수 없는 문제인 것 같습니다.
좌표를 2배로 키워 계산한 뒤 결과값을 다시 2로 나눠주어 해결하였습니다.

## 📚 문제 풀이 핵심 키워드
- BFS
- 좌표 확장

## 🤔 리뷰로 궁금한 점
없습니다.

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?
