### PR TITLE
solved 아이템줍기 - 18.12ms 92.5mb

### DIFF
--- a/Programmers/아이템줍기/아이템줍기_최효빈.java
+++ b/Programmers/아이템줍기/아이템줍기_최효빈.java
@@ -1,0 +1,105 @@
+package graph.BFS;
+
+import java.util.*;
+
+
+public class 아이템줍기_최효빈 {
+
+    boolean[][] visited;
+    final int MAX = 1 + 50 * 2 + 1;
+
+    boolean isOuttaBound(int x, int y){
+        return x < 0 || y < 0 || x >= MAX || y >= MAX || visited[x][y];
+    }
+
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+
+        int[] octX = { 0, 0,-1, 1,-1,-1, 1,1};
+        int[] octY = {-1, 1, 0, 0, 1,-1,-1,1};
+
+        int[] dX = {0,0,-1,1};
+        int[] dY = {-1,1,0,0};
+        // 상, 하, 좌, 우
+
+        characterX *= 2;
+        characterY *= 2;
+        itemX *= 2;
+        itemY *= 2;
+
+        boolean[][] isArea = new boolean[MAX][MAX];
+        boolean[][] isOutline = new boolean[MAX][MAX];
+
+
+        for(int[] rect : rectangle){
+            int startX = rect[0] * 2;
+            int startY = rect[1] * 2;
+            int endX = rect[2] * 2;
+            int endY = rect[3] * 2;
+
+            for(int x = startX; x <= endX; x++){
+                for(int y = startY; y <= endY; y++){
+                    isArea[x][y] = true;
+                }
+            }
+        }
+
+        Queue<int[]> que = new ArrayDeque<>();
+        que.offer(new int[]{0, 0});
+        visited = new boolean[MAX][MAX];
+
+        while(!que.isEmpty()){
+            int[] curr = que.poll();
+            int x = curr[0];
+            int y = curr[1];
+
+            int nx, ny;
+            for(int dir = 0; dir < 8; dir++){
+                nx = x + octX[dir];
+                ny = y + octY[dir];
+
+                if(isOuttaBound(nx, ny))
+                    continue;
+
+                visited[nx][ny] = true;
+
+                if(isArea[nx][ny])
+                    isOutline[nx][ny] = true;
+                else
+                    que.offer(new int[]{nx, ny});
+            }
+        }
+
+        que.offer(new int[]{characterX, characterY, 0});
+        visited = new boolean[MAX][MAX];
+        visited[characterX][characterY] = true;
+
+        while(!que.isEmpty()){
+            int[] curr = que.poll();
+            int x = curr[0];
+            int y = curr[1];
+            int count = curr[2];
+
+            if(x == itemX && y == itemY){
+                return count / 2;
+            }
+
+            int nx, ny;
+            for(int dir = 0; dir < 4; dir++){
+                nx = x + dX[dir];
+                ny = y + dY[dir];
+
+                if(isOuttaBound(nx, ny) || !isOutline[nx][ny])
+                    continue;
+
+                visited[nx][ny] = true;
+                que.offer(new int[]{nx, ny, count+1});
+            }
+        }
+
+
+        return 0;
+    }
+
+}
+
+


### PR DESCRIPTION
## 💿 풀이 문제
#91 

## 📝 풀이 후기
반례를 잘 고려해야 하는 까다로운 BFS 문제

## 📚 문제 풀이 핵심 키워드
- 총 2번의 BFS를 실행합니다. 첫 번째는 Flood-Fill로 사각형들으로 구성된 영역의 외곽선을 따고, 두 번째는 외곽선 상에서 최단거리를 찾습니다.
- [Flood-Fill을 수행할 때] 4방 탐색을 하면 꼭짓점이 포함되지 않습니다. 8방 탐색으로 꼭짓점까지 포함시켜 줍니다.
- [외곽선 상에서 최단거리를 찾을 때] 외곽선 경로를 벗어나 평행하는 선 사이를 건너뛰는 경우가 있습니다. 
두 좌표가 선으로 연결된 경우와 단순히 좌표의 거리 차이가 1인 경우를 구분짓지 않았기 때문입니다.
(테스트 케이스에서 정답보다 2만큼 작은 값이 출력되는 이유입니다.)
풀이 코드에서 모든 좌표에 2를 곱하고, 출력값에 2를 나눈 이유가 이것입니다. 모든 좌표에 2를 곱하면 수직선상으로 연결되지 않은 모든 점 좌표들은 최소 2에 해당하는 거리 차이가 나게 됩니다. 

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?