### PR TITLE
solved 연속펄스부분수열의합 - 36.39ms, 121MB

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_김훈민.java
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_김훈민.java
@@ -1,0 +1,41 @@
+class Solution {
+    long[] oddArr;
+    long[] evenArr;
+    long result = Long.MIN_VALUE;
+    int len;
+    public long solution(int[] sequence) {
+        len = sequence.length;
+        oddArr = new long[sequence.length];
+        evenArr = new long[sequence.length];
+        calcArrValue(sequence);
+        findMaxValue(oddArr);
+        findMaxValue(evenArr);
+        return result;
+    }
+
+    void calcArrValue(int[] seq){
+        boolean even = true;
+        oddArr[0] = seq[0] * -1;
+        evenArr[0] = seq[0];
+        for(int i = 1; i < seq.length; i++){
+            if(even){
+                evenArr[i] += (evenArr[i-1] + seq[i] * -1);
+                oddArr[i] += (oddArr[i-1] + seq[i]);
+            } else {
+                evenArr[i] += (evenArr[i-1] + seq[i]);
+                oddArr[i] += (oddArr[i-1] + seq[i] * -1);
+            }
+            even = !even;
+        }
+    }
+
+    void findMaxValue(long[] arr){
+        long minValue = 0;
+        long maxSubValue = Long.MIN_VALUE;
+        for(int i = 0; i < arr.length; i++){
+            maxSubValue = Math.max(maxSubValue, arr[i] - minValue);
+            minValue = Math.min(minValue, arr[i]);
+        }
+        result = Math.max(result, maxSubValue);
+    }
+}


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
쉬웠습니다.

## 📚 문제 풀이 핵심 키워드
미리 두가지 종류에 대한 펄스의 합을 구해놓고 누적합을 사용했습니다.

## 🤔 리뷰로 궁금한 점


## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.