### PR TITLE
unsolved 연속펄스부분수열의합

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_최효빈.java
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_최효빈.java
@@ -1,0 +1,22 @@
+class Solution {
+    public long solution(int[] sequence) {
+        long[] acc = new long[sequence.length];
+        acc[0] = sequence[0];
+        
+        for(int i = 1; i < sequence.length; i++){
+            acc[i] = acc[i-1] + sequence[i] * (i % 2 == 0 ? 1 : -1);
+        }
+        
+        long answer = Math.max(acc[0], -acc[0]);
+        
+        for(int i = 1; i < sequence.length; i++){
+            answer = Math.max(answer, Math.max(acc[i], -acc[i]));
+            for(int j = 0; j < i; j++){
+                long value = acc[i] - acc[j];
+                answer = Math.max(answer, Math.max(value, -value));
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
누적합 풀이를 시도했지만 시간 초과가 발생했습니다.  
수열 합의 절댓값을 기준으로 정렬하는 탐욕법 풀이를 떠올려 봤지만, 항상 정답을 출력할 방법이 떠오르지 않았습니다.

## 📚 문제 풀이 핵심 키워드
- 누적합
- 탐욕법

## 🤔 리뷰로 궁금한 점
.

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.