### PR TITLE
solved 연속펄스부분수열의합 - 701.15ms 70.2mb

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_조우재.py
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_조우재.py
@@ -1,0 +1,17 @@
+def search(pulse):
+    best_optimal = float("-inf")
+    optimal = 0
+    for num in pulse:
+        optimal = max(num, optimal + num)  # 현재 수를 더했을 때 크게 되는지, 현재수만 선택했을 때 크게 되는지
+        best_optimal = max(best_optimal, optimal)  # 그 값이 최적의 값인지
+
+    return best_optimal
+
+
+def solution(sequence):
+    n = len(sequence)
+
+    pulse1 = [sequence[i] * (1 if i % 2 == 0 else -1) for i in range(n)]
+    pulse2 = [sequence[i] * (-1 if i % 2 == 0 else 1) for i in range(n)]
+
+    return max(search(pulse1), search(pulse2))


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
중간정도 난이도인 거 같습니다.

## 📚 문제 풀이 핵심 키워드
- n^2으로는 풀 수 없으니 그 이하로 풀이해야 함
- 수들을 연속적으로 더해나가되, 더할 수가 지금의 수보다 크다면 해당 수부터 다시 더함
- 펄스별로 나눠서 확인

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.