### PR TITLE
solved 연속펄스부분수열의합 - 88.18ms 30.7mb

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_이정명.py
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_이정명.py
@@ -1,0 +1,18 @@
+def solution(sequence):
+    sign = [-1, 1]
+    
+    current = 0
+    minimum = 0
+    maximum = 0
+    
+    if len(sequence) == 1 :
+        return (-sequence[0] if sequence[0]<0 else sequence[0])
+    
+    for i, num in enumerate(sequence):
+        current += num * sign[i%2]
+        if minimum > current :
+            minimum = current
+        if maximum < current :
+            maximum = current
+            
+    return maximum - minimum


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
- 풀이는 어렵지 않았으나, 아무것도 없는 경우를 고려해야 한다는 것을 간과했습니다.

## 📚 문제 풀이 핵심 키워드
- 시간복잡도 문제는 없을 것 같아 누적합으로만 풀이하고 안전하게 푸는 것을 목적으로 풀었습니다.

## 🤔 리뷰로 궁금한 점
X

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?