### PR TITLE
unsolved 연속 펄스 부분 수열의 합 - 26.23ms, 133MB

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_김수빈.java
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_김수빈.java
@@ -1,0 +1,29 @@
+import java.util.*;
+
+class Solution {
+    private static long kadane(int[] seq) {
+        long max = seq[0];
+        long curr = seq[0];
+        
+        for (int i = 1; i < seq.length; i++) {
+            curr = Math.max(seq[i], curr + seq[i]);
+            max = Math.max(max, curr);
+        }
+        
+        return max;
+    }
+    
+    public long solution(int[] sequence) {
+        int[] seq1 = new int[sequence.length];
+        int[] seq2 = new int[sequence.length];
+        int x = 1;
+        for (int i = 0; i < sequence.length; i++) {
+            seq1[i] = sequence[i] * x;
+            x *= -1;
+            seq2[i] = sequence[i] * x;
+        }
+
+        long answer = Math.max(kadane(seq1), kadane(seq2));
+        return answer;
+    }
+}


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
카데인 알고리즘 몰라서 브루트포스로 풀다가 틀렸다

## 📚 문제 풀이 핵심 키워드
- 카데인알고리즘 

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [X] Convention(commit, pr 제목)이 올바른가요?
- [X] 괄호 내 안내문은 삭제하셨나요?
- [X] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?