### PR TITLE
solved 후보키 - 7.50ms 9.57mb

### DIFF
--- a/Programmers/후보키/후보키_조우재.py
+++ b/Programmers/후보키/후보키_조우재.py
@@ -1,0 +1,17 @@
+from itertools import combinations
+
+
+def solution(relation):
+    row = len(relation)
+    col = len(relation[0])
+    candidates = []
+
+    for i in range(1, col + 1):  # 가능한 모든 속성 조합
+        for comb in combinations(range(col), i):  # 유일성 체크
+            temp = {tuple(item[j] for j in comb) for item in relation}
+            if len(temp) == row:  # 중복이 없다면 유일성 만족
+                if not any(set(candidate).issubset(set(comb)) for candidate in
+                           candidates):  # 최소성 체크 -> 후보키가 유일키의 서브셋이라면 해당 유일키는 후보키가 불가능
+                    candidates.append(comb)
+
+    return len(candidates)


### PR DESCRIPTION
## 💿 풀이 문제
#352 

## 📝 풀이 후기
cs 지식이 있으면 쉽게 풀어낼 수 있는 신선한 문제였습니다.

## 📚 문제 풀이 핵심 키워드
- 이미 생성된 후보키가 유일성을 만족하는 키의 서브셋이라면 유일성을 만족하는 키는 후보키가 될 수 없다.

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.