### PR TITLE
solved 연속펄스부분수열의합 - 27.56ms 127mb

### DIFF
--- a/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_허승경.java
+++ b/Programmers/연속펄스부분수열의합/연속펄스부분수열의합_허승경.java
@@ -1,0 +1,31 @@
+import java.util.*;
+
+class Solution {
+    public long solution(int[] sequence) {
+        int [] arr1 = new int[sequence.length]; // 1로 시작
+        int [] arr2 = new int[sequence.length]; // -1로 시작
+        
+        int sign = 0;
+        for(int i = 0; i < sequence.length; i++){
+            if(i%2 == 0)sign = 1;
+            else sign = -1;
+            
+            arr1[i] = sequence[i]*sign;
+            arr2[i] = sequence[i]*-sign;
+        }
+
+        return Math.max(getMaxSequence(arr1), getMaxSequence(arr2));
+    }
+    
+    long getMaxSequence(int [] arr){
+        long maxSum = arr[0];   // 전체 수열 좀 전체값
+        long curSum = arr[0];   // 현재 수열의 값
+        
+        for(int i = 1; i < arr.length; i++){
+            curSum = Math.max(arr[i], curSum+arr[i]);   // 현재 단독, 이전값+현재값
+            maxSum = Math.max(maxSum, curSum);
+        }
+        
+        return maxSum;
+    }
+}


### PR DESCRIPTION
## 💿 풀이 문제
#350 

## 📝 풀이 후기
처음에는 이분탐색인줄 알았는데, 1과 -1이 반복되고, 음수도 있어 1로 시작하는 배열과 -1로 시작하는 배열을 만들어 풀었습니다.

## 📚 문제 풀이 핵심 키워드
- 각각의 케이스 구하기

## 🤔 리뷰로 궁금한 점
<!-- 확인받고 싶은 기준을 작성해주시면 좋습니다. -->
<!-- 운영자에게 리뷰를 받고 싶다면, Reviewer에 @hadevyi를 태그해주세요. -->

## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?